### PR TITLE
Set contract compiler port to default for constellation

### DIFF
--- a/examples/contracts.py
+++ b/examples/contracts.py
@@ -72,7 +72,7 @@ def main():
     address2 = Address(entity2)
 
     # build the ledger API
-    api = LedgerApi('127.0.0.1', 8100)
+    api = LedgerApi('127.0.0.1', 8000)
 
     # create wealth so that we have the funds to be able to create contracts on the network
     api.sync(api.tokens.wealth(entity1, 10000))


### PR DESCRIPTION
Constellation by default runs on 8000, not 8100. Changed this alone in `contracts.py`, which now matches the other examples.