### PR TITLE
Added functionality required for unit testing in etch-tools

### DIFF
--- a/fetchai/ledger/__init__.py
+++ b/fetchai/ledger/__init__.py
@@ -1,5 +1,5 @@
 # Ledger version that this API is compatible with
-__version__ = '0.9.0-a1'
+__version__ = '0.9.0-a2'
 # This API is compatible with ledgers that meet all the requirements listed here:
 __compatible__ = ['<0.10.0', '>=0.8.0-alpha']
 

--- a/fetchai/ledger/parser/etch.grammar
+++ b/fetchai/ledger/parser/etch.grammar
@@ -42,7 +42,7 @@ bool_expression: expression
                | bool_expression BOOLEAN_OP bool_expression
 
 annotation: "@"ANNOTATION function
-ANNOTATION: "init"|"action"|"query"|"problem"|"objective"|"work"|"clear"
+ANNOTATION: "initTest"|"init"|"action"|"query"|"problem"|"objective"|"work"|"clear"|"test"
 
 function: "function" NAME parameter_block (":" TYPE)? code_block? "endfunction"
 

--- a/fetchai/ledger/parser/etch.grammar
+++ b/fetchai/ledger/parser/etch.grammar
@@ -52,8 +52,6 @@ typed_name: NAME ":" type
 
 input_block: "(" (expression ",")* expression? ")"
 
-template_block: "<" type ">"
-
 code_block: instruction+
 
 comment: "//" /.+/

--- a/fetchai/ledger/parser/etch.grammar
+++ b/fetchai/ledger/parser/etch.grammar
@@ -18,23 +18,23 @@ instruction: "use" NAME [use_shard] ";"                         -> use_global
 
 instantiation: "var" NAME "=" expression ";"
 
-declaration: "var" NAME ":" TYPE ";"
+declaration: "var" NAME ":" type ";"
 
 range: (expression) | (expression ":" expression) | (expression ":" expression ":" expression)
 
 expression: NUMBER
-          | dot_expansion
           | name
+          | dot_expansion
           | STRING_LITERAL
           | PRE_UNARY expression
           | expression POST_UNARY
           | expression BINARY_OP expression
           | function_call
-          | TYPE input_block
+          | type input_block
 
 function_call: expression input_block
 
-dot_expansion: name ("." name)+
+dot_expansion: expression ("." expression)+
 
 bool_expression: expression
                | PRE_UNARY bool_expression
@@ -44,15 +44,15 @@ bool_expression: expression
 annotation: "@"ANNOTATION function
 ANNOTATION: "initTest"|"init"|"action"|"query"|"problem"|"objective"|"work"|"clear"|"test"
 
-function: "function" NAME parameter_block (":" TYPE)? code_block? "endfunction"
+function: "function" NAME parameter_block (":" type)? code_block? "endfunction"
 
 parameter_block: "(" (typed_name ","?)* ")"
 
-typed_name: NAME ":" TYPE
+typed_name: NAME ":" type
 
 input_block: "(" (expression ",")* expression? ")"
 
-template_block: "<" TYPE ">"
+template_block: "<" type ">"
 
 code_block: instruction+
 
@@ -85,21 +85,21 @@ NAME: LETTER (LETTER|"_"|INT)*
 
 indexed_name: name "[" (NUMBER|STRING_LITERAL|name) "]"
 
-NUMBER: INT INLINE_INT?
+NUMBER: INT INLINE_INT?   // TODO: drop support for untyped number
 
 STRING_LITERAL: (/\"(\\.|[^"\\])*\"/)|(/\'(\\.|[^'\\])*\'/)
 
-TYPE: BASIC_TYPE|TEMPLATE_TYPE|FLOAT_TYPE|FIXED_TYPE|OTHER_TYPE
+?type: BASIC_TYPE|template_type|FLOAT_TYPE|FIXED_TYPE|NAME
 
-TEMPLATE_TYPE: ("Array"|"Map"|"State") "<" (BASIC_TYPE|OTHER_TYPE ",")* (BASIC_TYPE|OTHER_TYPE) ">"
+template_type: type "<" template_arg_list ">"
+
+template_arg_list: type? ("," type)*
 
 BASIC_TYPE: "U"? "Int" ("256"|"64"|"32"|"16"|"8")
 
 FLOAT_TYPE: "Float" ("64"|"32")
 
 FIXED_TYPE: "Fixed" ("64"|"32")
-
-OTHER_TYPE: "Boolean"|"Address"|"String"|"State"|"Array"|"Map"|"StructuredData"|"Graph"|"DataLoader"|"Optimiser"|"Tensor"
 
 INLINE_INT: ("u"|"i") INT
 

--- a/fetchai/ledger/parser/etch.grammar
+++ b/fetchai/ledger/parser/etch.grammar
@@ -16,7 +16,7 @@ instruction: "use" NAME [use_shard] ";"                         -> use_global
            | instruction ";"                                    -> line
            | comment
 
-instantiation: "var" NAME "=" expression ";"
+instantiation: "var" (typed_name | NAME) "=" expression ";"
 
 declaration: "var" NAME ":" type ";"
 

--- a/fetchai/ledger/parser/etch_parser.py
+++ b/fetchai/ledger/parser/etch_parser.py
@@ -86,16 +86,18 @@ class PersistentGlobal:
 
 
 class Function:
-    def __init__(self, name, parameters, return_type=None, annotation=None, code_block=None):
+    def __init__(self, name, parameters, return_type=None, annotation=None, code_block=None, lines=None):
         self.name = name
         self.parameters = parameters
         self.return_type = return_type
         self.annotation = annotation
         self.code_block = code_block
+        self.lines = lines
 
     @staticmethod
     def from_tree(tree: tree.Tree):
         # Parse annotation parent node
+        lines = (tree.line, tree.end_line)
         if tree.data == 'annotation':
             annotation = tree.children[0].value
             tree = tree.children[1]
@@ -124,7 +126,7 @@ class Function:
             assert len(code_block) == 1, "Found more than one code block"
             code_block = code_block[0]
 
-        return Function(function_name, parameters, return_type, annotation, code_block)
+        return Function(function_name, parameters, return_type, annotation, code_block, lines=lines)
 
     @staticmethod
     def all_from_tree(tree: tree.Tree):
@@ -150,7 +152,7 @@ class EtchParser:
     def __init__(self, etch_code=None):
         # Load grammar
         self.grammar = resource_string(__name__, 'etch.grammar').decode('ascii')
-        self.parser = Lark(self.grammar)
+        self.parser = Lark(self.grammar, propagate_positions=True)
 
         self.parsed_tree = None
         self.etch_code = None

--- a/fetchai/ledger/parser/etch_parser.py
+++ b/fetchai/ledger/parser/etch_parser.py
@@ -113,7 +113,7 @@ class Function:
         parameters = [Parameter(n.children[0].value, n.children[1].value) for n in tree.children[1].children]
 
         # Check for output type
-        if len(tree.children) > 2 and isinstance(tree.children[2], lexer.Token) and tree.children[2].type == 'TYPE':
+        if len(tree.children) > 2 and isinstance(tree.children[2], lexer.Token):
             return_type = tree.children[2].value
         else:
             return_type = None
@@ -258,7 +258,6 @@ class EtchParser:
                 g_type = None
             else:
                 assert g_name_node.children[0].type == 'NAME'
-                assert g_name_node.children[1].type == 'TYPE'
                 g_name = g_name_node.children[0].value
                 g_type = g_name_node.children[1].value
 

--- a/fetchai/ledger/parser/etch_parser.py
+++ b/fetchai/ledger/parser/etch_parser.py
@@ -178,7 +178,7 @@ class EtchParser:
             entry_points[ep] = []
 
         # Parse all functions in tree
-        functions = Function.all_from_tree(self.parsed_tree)
+        functions = self.get_functions()
 
         # Add functions with annotation to entry point dict
         for f in functions:
@@ -187,16 +187,20 @@ class EtchParser:
 
         return entry_points
 
+    def get_functions(self):
+        """Returns a list of all functions found in source"""
+        return Function.all_from_tree(self.parsed_tree)
+
     def subfunctions(self):
         """Identify functions that are not entry points"""
-        functions = Function.all_from_tree(self.parsed_tree)
+        functions = self.get_functions()
         return list(f.name for f in functions if f.annotation is None)
 
     def global_using_subfunctions(self):
         """Return a dict of non entry functions, listing any global use statements they contain"""
         globals_used = {}
 
-        functions = Function.all_from_tree(self.parsed_tree)
+        functions = self.get_functions()
 
         for f in functions:
             if f.annotation:

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -220,14 +220,17 @@ class ParserTests(unittest.TestCase):
 
         # As above, for map type
         tree = self.parser.parse(FUNCTION_BLOCK.format("var myArray = Map<String, Int32>(5);"))
-        # # Test assignment to array
+        # Test assignment to array
         tree = self.parser.parse(FUNCTION_BLOCK.format("myArray['test'] = 5;"))
-        # # Test assignment from array
+        # Test assignment from array
         tree = self.parser.parse(FUNCTION_BLOCK.format("b = myArray['test'];"))
         tree = self.parser.parse(FUNCTION_BLOCK.format("var b = myArray['test'];"))
 
-    def test_inline(self):
-        """Tests for correct parsing of inline type annotations"""
+    def test_instantiation(self):
+        """Tests for correct parsing of valid variable instantiation"""
+        # Check that the following parse without error
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var b = get();"))           # Untyped instantiation
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var b : UInt64 = get();"))  # Typed instantiation
 
     def test_template(self):
         """Tests for correct parsing of template variables"""

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -74,6 +74,28 @@ class ParserTests(unittest.TestCase):
         except GrammarError as e:
             self.fail("Etch grammar failed to load with: \n" + str(e))
 
+    def test_get_functions(self):
+        """Check that functions properly identified"""
+        functions = self.parser.get_functions()
+
+        # Check all functions found
+        function_dict = {f.name: f for f in functions}
+        self.assertTrue(all(n in function_dict.keys() for n in ['setup', 'transfer', 'balance', 'sub']))
+
+        # Check transfer parsed
+        self.assertEqual(function_dict['transfer'].annotation, 'action')
+        self.assertEqual(function_dict['transfer'].lines, (11, 24))
+        self.assertIsNotNone(function_dict['transfer'].code_block)
+
+        # Check return value correctly parsed
+        self.assertEqual(function_dict['balance'].return_type, 'UInt64')
+
+        # Check parameter block correctly parsed
+        self.assertEqual(len(function_dict['setup'].parameters), 1)
+        self.assertIsNone(function_dict['setup'].parameters[0].value)
+        self.assertEqual(function_dict['setup'].parameters[0].name, 'owner')
+        self.assertEqual(function_dict['setup'].parameters[0].ptype, 'Address')
+
     def test_entry_points(self):
         entry_points = self.parser.entry_points()
         self.assertIn('init', entry_points)


### PR DESCRIPTION
- save line numbers of parsed functions, for use in reporting on unit tests
- added 'get_functions' to EtchParser, for getting a list of functions with details
- correctly parse multi-type templates:
`a : Map<String, UInt32>;`
- correctly parse nested function calls, e.g.:  (fixes LDGR-414)
`a = b.get(c).get(d);`