### PR TITLE
Add correct parsing of binary comparison operation + test

### DIFF
--- a/fetchai/ledger/parser/etch.grammar
+++ b/fetchai/ledger/parser/etch.grammar
@@ -29,6 +29,7 @@ expression: NUMBER
           | PRE_UNARY expression
           | expression POST_UNARY
           | expression BINARY_OP expression
+          | expression COMPARISON expression
           | function_call
           | type input_block
 

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -311,3 +311,18 @@ class ParserTests(unittest.TestCase):
             tree = self.parser.parse(NESTED_FUNCTION)
         except:
             self.fail("Parsing of dot nested function calls failed")
+
+    def test_expressions(self):
+        """Check that common expressions parse correctly"""
+        # Instantiation
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var a = 1i32;"))
+        # Binary operation
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var a = 1i32 + 2i32;"))
+        # Pre-unary operation
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var a = - 2i32;"))
+        # Post-unary operation
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var a = 2i32++;"))
+        # Comparison operation
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var a = 2i32 == 3i32;"))
+        # Type cast
+        tree = self.parser.parse(FUNCTION_BLOCK.format("var a = Int64(3i32);"))


### PR DESCRIPTION
Minor fix enabling parsing of binary comparison statements, e.g.: a == b