### PR TITLE
Query transaction content

### DIFF
--- a/fetchai/ledger/api/__init__.py
+++ b/fetchai/ledger/api/__init__.py
@@ -15,11 +15,9 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-import json
 import logging
 import time
 from datetime import datetime, timedelta
-from pprint import PrettyPrinter
 from typing import Sequence, Union
 
 import semver

--- a/fetchai/ledger/api/__init__.py
+++ b/fetchai/ledger/api/__init__.py
@@ -15,6 +15,7 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
+
 import logging
 import time
 from datetime import datetime, timedelta

--- a/fetchai/ledger/api/__init__.py
+++ b/fetchai/ledger/api/__init__.py
@@ -15,10 +15,11 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
+import json
 import logging
 import time
 from datetime import datetime, timedelta
+from pprint import PrettyPrinter
 from typing import Sequence, Union
 
 import semver
@@ -83,6 +84,13 @@ class LedgerApi:
         while True:
             # loop through all the remaining digests and poll them creating a set of completed in this round
             remaining_statuses = [self.tx.status(digest) for digest in remaining]
+
+            pp = PrettyPrinter(indent=2, width=90)
+            conts = [self.tx._contents(digest) for digest in remaining]
+            for c in conts:
+                pp.pprint(c.__dict__)
+                print(c.signatories)
+            # print('\n'.join(pp.pprint(c.__dict__) for c in conts))
 
             failed_this_round = [status for status in remaining_statuses if status.failed]
             if failed_this_round:

--- a/fetchai/ledger/api/__init__.py
+++ b/fetchai/ledger/api/__init__.py
@@ -85,13 +85,6 @@ class LedgerApi:
             # loop through all the remaining digests and poll them creating a set of completed in this round
             remaining_statuses = [self.tx.status(digest) for digest in remaining]
 
-            pp = PrettyPrinter(indent=2, width=90)
-            conts = [self.tx._contents(digest) for digest in remaining]
-            for c in conts:
-                pp.pprint(c.__dict__)
-                print(c.signatories)
-            # print('\n'.join(pp.pprint(c.__dict__) for c in conts))
-
             failed_this_round = [status for status in remaining_statuses if status.failed]
             if failed_this_round:
                 failures = ['{}:{}'.format(tx_status.digest_hex, tx_status.status) \

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import base64
 import json
 from collections import defaultdict
@@ -83,10 +84,11 @@ class TxContents:
         return self.transfers.get(address, 0)
 
     @staticmethod
-    def from_json(data: Union[dict, str]):
+    def from_json(data: Union[dict, str]) -> TxContents:
         """Creates a TxContents from a json string or dict object"""
         if isinstance(data, str):
             data = json.loads(data)
+
         # Extract contents from json, converting as necessary
         return TxContents(
             bytes.fromhex(data.get('digest').lstrip('0x')),
@@ -128,7 +130,17 @@ class TransactionApi(ApiEndpoint):
             charge_rate=int(response['charge_rate']),
             fee=int(response['fee']))
 
-    def _contents(self, tx_digest):
+    def contents(self, tx_digest) -> TxContents:
+        """
+        Returns the contents of the transaction at the node
+
+        :param tx_digest: The hex-encoded string of the target tx digest
+        :return: TxContents object
+        """
+
+        return self._contents(tx_digest)
+
+    def _contents(self, tx_digest) -> TxContents:
         url = '{}://{}:{}/api/tx/{}'.format(self.protocol, self.host, self.port, tx_digest)
 
         response = self._session.get(url).json()

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from collections import defaultdict
 
 from .common import ApiEndpoint
 
@@ -68,7 +69,7 @@ class TxContents:
         self.valid_until = valid_until
         self.charge = charge
         self.charge_limit = charge_limit
-        self.transfers = transfers
+        self._transfers = transfers
         self.signatories = signatories
         self.data = data
 
@@ -78,11 +79,20 @@ class TxContents:
             if item['to'] == address:
                 total += item['amount']
 
+    @property
+    def transfers(self):
+        result = defaultdict(list)
+        for item in self._transfers:
+            result[item['to']] += item['amount']
+
+        return dict(result)
+
     @staticmethod
     def from_json(data):
         if isinstance(data, str):
             data = json.loads(data)
         # Extract contents from json, converting as necessary
+        print(', '.join(data.keys()))
         return TxContents(
             bytes.fromhex(data.get('digest').lstrip('0x')),
             data.get('action'),

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -1,3 +1,6 @@
+import base64
+import json
+
 from .common import ApiEndpoint
 
 
@@ -38,6 +41,59 @@ class TxStatus:
         return self._digest_bytes
 
 
+class TxContents:
+    def __init__(self,
+                 digest: bytes,
+                 action: str,
+                 chain_code: str,
+                 from_address: str,
+                 contract_digest: str,
+                 contract_address: str,
+                 valid_from: int,
+                 valid_until: int,
+                 charge: int,
+                 charge_limit: int,
+                 transfers: list,
+                 signatories: list,
+                 data: str
+                 ):
+        self._digest_bytes = digest
+        self._digest_hex = self._digest_bytes.hex()
+        self.action = action
+        self.chain_code = chain_code
+        self.from_address = from_address
+        self.contract_digest = contract_digest
+        self.contract_address = contract_address
+        self.valid_from = valid_from
+        self.valid_until = valid_until
+        self.charge = charge
+        self.charge_limit = charge_limit
+        self.transfers = transfers
+        self.signatories = signatories
+        self.data = data
+
+    @staticmethod
+    def from_json(data):
+        if isinstance(data, str):
+            data = json.loads(data)
+        # Extract contents from json, converting as necessary
+        return TxContents(
+            bytes.fromhex(data.get('digest').lstrip('0x')),
+            data.get('action'),
+            data.get('chainCode'),
+            data.get('from'),
+            data.get('contractDigest'),
+            data.get('contractAddress'),
+            int(data.get('validFrom', 0)),
+            int(data.get('validUntil', 0)),
+            int(data.get('charge')),
+            int(data.get('chargeLimit')),
+            [t for t in data.get('transfers')],
+            [bytes.fromhex(s.lstrip('0x')) for s in data.get('signatories')],
+            data['data']
+        )
+
+
 class TransactionApi(ApiEndpoint):
     def status(self, tx_digest):
         """
@@ -53,11 +109,21 @@ class TransactionApi(ApiEndpoint):
         url = '{}://{}:{}/api/status/tx/{}'.format(self.protocol, self.host, self.port, tx_digest)
 
         response = self._session.get(url).json()
-
+        print('digest: ', response['tx'])
         return TxStatus(
-            digest=bytes.fromhex(response['tx']),
+            digest=base64.b64decode(response['tx'].encode()),
             status=str(response['status']),
             exit_code=int(response['exit_code']),
             charge=int(response['charge']),
             charge_rate=int(response['charge_rate']),
             fee=int(response['fee']))
+
+    def _contents(self, tx_digest):
+        url = '{}://{}:{}/api/tx/{}'.format(self.protocol, self.host, self.port, tx_digest)
+
+        response = self._session.get(url).json()
+
+        return TxContents.from_json(response)
+
+
+

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -1,5 +1,3 @@
-import base64
-
 from .common import ApiEndpoint
 
 
@@ -57,7 +55,7 @@ class TransactionApi(ApiEndpoint):
         response = self._session.get(url).json()
 
         return TxStatus(
-            digest=base64.b64decode(response['tx'].encode()),
+            digest=bytes.fromhex(response['tx']),
             status=str(response['status']),
             exit_code=int(response['exit_code']),
             charge=int(response['charge']),

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -72,6 +72,12 @@ class TxContents:
         self.signatories = signatories
         self.data = data
 
+    def transfers_to(self, address):
+        total = 0
+        for item in self.transfers:
+            if item['to'] == address:
+                total += item['amount']
+
     @staticmethod
     def from_json(data):
         if isinstance(data, str):
@@ -90,7 +96,7 @@ class TxContents:
             int(data.get('chargeLimit')),
             [t for t in data.get('transfers')],
             [bytes.fromhex(s.lstrip('0x')) for s in data.get('signatories')],
-            data['data']
+            data.get('data')
         )
 
 

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -120,6 +120,7 @@ class TransactionApi(ApiEndpoint):
         url = '{}://{}:{}/api/status/tx/{}'.format(self.protocol, self.host, self.port, tx_digest)
 
         response = self._session.get(url).json()
+
         return TxStatus(
             digest=base64.b64decode(response['tx'].encode()),
             status=str(response['status']),

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
 import base64
 import json
-from collections import defaultdict
 from typing import Union, List, Dict, Optional
 
 from fetchai.ledger.crypto import Address, Identity
@@ -84,7 +82,7 @@ class TxContents:
         return self.transfers.get(address, 0)
 
     @staticmethod
-    def from_json(data: Union[dict, str]) -> TxContents:
+    def from_json(data: Union[dict, str]):
         """Creates a TxContents from a json string or dict object"""
         if isinstance(data, str):
             data = json.loads(data)

--- a/tests/api/test_txcontents.py
+++ b/tests/api/test_txcontents.py
@@ -1,0 +1,101 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+import requests
+
+from fetchai.ledger.api import TransactionApi
+from fetchai.ledger.api.tx import TxContents
+from fetchai.ledger.crypto import Address, Identity, Entity
+
+
+class TXContentsTest(TestCase):
+    def test_init(self):
+        pass
+
+    @patch('fetchai.ledger.api.tx.TxContents', spec=TxContents)
+    def test_contents(self, mock_contents):
+        """Check that transcation api correctly queries for and returns contents"""
+        # Api object
+        api = TransactionApi('abc', 1234)
+
+        # Sessions mock for receiving URL request
+        mock_session = Mock(spec=requests.Session)
+        api._session = mock_session
+
+        # Mock response returned by session
+        mock_response = Mock(spec=requests.Response)
+        mock_response.json.side_effect = ['json']
+        mock_session.get.side_effect = [mock_response]
+
+        # Mock TxContents static constructor
+        mock_contents.from_json.side_effect = ['txcontents']
+
+        # Call method under test
+        result = api.contents('fegh')
+
+        # Check that correct url retrieved
+        mock_session.get.assert_called_once_with('http://abc:1234/api/tx/fegh')
+        # Check that json result retrieved
+        mock_response.json.assert_called_once_with()
+        # Check that static constructor called
+        mock_contents.from_json.assert_called_once_with('json')
+        # Check that correct result returned
+        self.assertEqual(result, 'txcontents')
+
+    def test_static_constructor(self):
+        data = {
+            'digest': '0x123456',
+            'action': 'transfer',
+            'chainCode': 'action.transfer',
+            'from': 'U5dUjGzmAnajivcn4i9K4HpKvoTvBrDkna1zePXcwjdwbz1yB',
+            'validFrom': 0,
+            'validUntil': 100,
+            'charge': 2,
+            'chargeLimit': 5,
+            'transfers': [],
+            'signatories': ['abc'],
+            'data': 'def'
+        }
+
+        a = TxContents.from_json(data)
+        self.assertEqual(a._digest_bytes, bytes.fromhex('123456'))
+        self.assertEqual(a._digest_hex, '123456')
+        self.assertEqual(a.action, 'transfer')
+        self.assertEqual(a.chain_code, 'action.transfer')
+        self.assertEqual(a.from_address, Address('U5dUjGzmAnajivcn4i9K4HpKvoTvBrDkna1zePXcwjdwbz1yB'))
+        self.assertIsNone(a.contract_digest)
+        self.assertIsNone(a.contract_address)
+        self.assertEqual(a.valid_from, 0)
+        self.assertEqual(a.valid_until, 100)
+        self.assertEqual(a.charge, 2)
+        self.assertEqual(a.charge_limit, 5)
+        self.assertEqual(a.transfers, {})
+        self.assertEqual(a.data, 'def')
+
+    def test_transfers(self):
+        to1 = Entity()
+        to2 = Entity()
+        to3 = Entity()
+
+        data = {
+            'digest': '0x123456',
+            'action': 'transfer',
+            'chainCode': 'action.transfer',
+            'from': 'U5dUjGzmAnajivcn4i9K4HpKvoTvBrDkna1zePXcwjdwbz1yB',
+            'validFrom': 0,
+            'validUntil': 100,
+            'charge': 2,
+            'chargeLimit': 5,
+            'signatories': ['abc'],
+            'data': 'def',
+            'transfers': [
+                {'to': to1, 'amount': 200},
+                {'to': to2, 'amount': 300}
+            ]
+        }
+
+        a = TxContents.from_json(data)
+
+        self.assertEqual(a.transfers_to(to1), 200)
+        self.assertEqual(a.transfers_to(to2), 300)
+        self.assertEqual(a.transfers_to(to3), 0)


### PR DESCRIPTION
Not for approval yet - initial questions:
- Are there more sensible data types for some of the extracted content (especially those currently stored as strings)?
- Other than digest type conversion, are there any other obvious properties to expose?

Also note that I'm still receiving base64 strings from the ledger for the status digest, rather than hex strings