### PR TITLE
This fix ensures Transfers exactness (the same behaviour as in Ledger)

### DIFF
--- a/fetchai/ledger/__init__.py
+++ b/fetchai/ledger/__init__.py
@@ -1,5 +1,5 @@
 # Ledger version that this API is compatible with
-__version__ = '0.11.0-a4'
+__version__ = '1.1.0-a1'
 # This API is compatible with ledgers that meet all the requirements listed here:
 __compatible__ = ['>=0.11.0-alpha.7']
 

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -3,6 +3,8 @@ from typing import Union, List, Dict, Optional
 
 from fetchai.ledger.crypto import Address, Identity
 from fetchai.ledger.decode import decode_hex_or_b64
+from fetchai.ledger.transaction import Transfer
+
 from .common import ApiEndpoint
 
 AddressLike = Union[Address, Identity, bytes, str]
@@ -76,14 +78,14 @@ class TxContents:
         self.valid_until = valid_until
         self.charge = charge
         self.charge_limit = charge_limit
-        self.transfers = [{Address(t['to']): int(t['amount'])} for t in transfers]
+        self.transfers = [Transfer(to=t['to'], amount=int(t['amount'])) for t in transfers]
         self.signatories = signatories
         self.data = data
 
     def transfers_to(self, address: AddressLike) -> int:
         """Returns the amount of FET transferred to an address by this transaction, if any"""
         address = Address(address)
-        return sum(t[address] for t in self.transfers if address in t)
+        return sum(t.amount for t in self.transfers if address == t.to)
 
     @staticmethod
     def from_json(data: Union[dict, str]):

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -83,7 +83,7 @@ class TxContents:
     def transfers_to(self, address: AddressLike) -> int:
         """Returns the amount of FET transferred to an address by this transaction, if any"""
         address = Address(address)
-        return [t[address] for t in self.transfers if address in t]
+        return sum(t[address] for t in self.transfers if address in t)
 
     @staticmethod
     def from_json(data: Union[dict, str]):

--- a/fetchai/ledger/api/tx.py
+++ b/fetchai/ledger/api/tx.py
@@ -76,14 +76,14 @@ class TxContents:
         self.valid_until = valid_until
         self.charge = charge
         self.charge_limit = charge_limit
-        self.transfers = {Address(t['to']): t['amount'] for t in transfers}
+        self.transfers = [{Address(t['to']): int(t['amount'])} for t in transfers]
         self.signatories = signatories
         self.data = data
 
     def transfers_to(self, address: AddressLike) -> int:
         """Returns the amount of FET transferred to an address by this transaction, if any"""
         address = Address(address)
-        return self.transfers.get(address, 0)
+        return [t[address] for t in self.transfers if address in t]
 
     @staticmethod
     def from_json(data: Union[dict, str]):

--- a/fetchai/ledger/serialisation/transaction.py
+++ b/fetchai/ledger/serialisation/transaction.py
@@ -75,9 +75,9 @@ def encode_payload(buffer: io.BytesIO, payload: transaction.Transaction):
     if num_transfers > 1:
         integer.encode(buffer, num_transfers - 2)
 
-    for destination, amount in payload.transfers.items():
-        address.encode(buffer, destination)
-        integer.encode(buffer, amount)
+    for transfer in payload.transfers:
+        address.encode(buffer, transfer.to)
+        integer.encode(buffer, transfer.amount)
 
     if has_valid_from:
         integer.encode(buffer, payload.valid_from)

--- a/fetchai/ledger/transaction.py
+++ b/fetchai/ledger/transaction.py
@@ -11,8 +11,8 @@ Identifier = Union[Address, Identity]
 class Transfer:
     def __init__(self, to: Identifier, amount: int):
         # ensure the address is correct
-        self.to: Address = Address(to)
-        self.amount: int = amount
+        self.to = Address(to)
+        self.amount = amount
 
     def __eq__(self, other):
         return isinstance(other, Transfer) and self.to == other.to and self.amount == other.amount

--- a/fetchai/ledger/transaction.py
+++ b/fetchai/ledger/transaction.py
@@ -27,7 +27,7 @@ TransferList = List[Transfer]
 class Transaction:
     def __init__(self):
         self._from = None
-        self._transfers: TransferList = []
+        self._transfers = []
         self._valid_from = 0
         self._valid_until = 0
         self._charge_rate = 0

--- a/tests/api/test_txcontents.py
+++ b/tests/api/test_txcontents.py
@@ -96,6 +96,6 @@ class TXContentsTest(TestCase):
 
         a = TxContents.from_json(data)
 
-        self.assertEqual(a.transfers_to(to1), [200])
-        self.assertEqual(a.transfers_to(to2), [300])
-        self.assertEqual(a.transfers_to(to3), [])
+        self.assertEqual(a.transfers_to(to1), 200)
+        self.assertEqual(a.transfers_to(to2), 300)
+        self.assertEqual(a.transfers_to(to3), 0)

--- a/tests/api/test_txcontents.py
+++ b/tests/api/test_txcontents.py
@@ -69,7 +69,7 @@ class TXContentsTest(TestCase):
         self.assertEqual(a.valid_until, 100)
         self.assertEqual(a.charge, 2)
         self.assertEqual(a.charge_limit, 5)
-        self.assertEqual(a.transfers, {})
+        self.assertEqual(a.transfers, [])
         self.assertEqual(a.data, 'def')
 
     def test_transfers(self):
@@ -96,6 +96,6 @@ class TXContentsTest(TestCase):
 
         a = TxContents.from_json(data)
 
-        self.assertEqual(a.transfers_to(to1), 200)
-        self.assertEqual(a.transfers_to(to2), 300)
-        self.assertEqual(a.transfers_to(to3), 0)
+        self.assertEqual(a.transfers_to(to1), [200])
+        self.assertEqual(a.transfers_to(to2), [300])
+        self.assertEqual(a.transfers_to(to3), [])


### PR DESCRIPTION
Until now, the python ledger python api stored transfers in
Transaction class as `OrderedDict` container, what came with
implication that separate transfers added by developer INDIVIDUALLY by
calling the `Transaction.add_transfer(...)` method were joined
(accumulated) together to single transfer for transfers with
**identical** destination address.

Ledger does not impose such a limitation on transfers collection in
Transaction, thus this change aligns the behaviour with limitations
defined by Ledger.