### PR TITLE
Adding local network to the API

### DIFF
--- a/fetchai/ledger/api/bootstrap.py
+++ b/fetchai/ledger/api/bootstrap.py
@@ -81,6 +81,11 @@ def split_address(address):
 
 def server_from_name(network):
     """Queries bootstrap for the requested network and returns connection details"""
+
+    # Adding a "local" network to give the looks and feel of main and testnet
+    if network == "local":
+        return "http://127.0.0.1", 8000
+
     # Get list of active servers
     server_list = list_servers(True)
 
@@ -93,4 +98,5 @@ def server_from_name(network):
     # Check if address contains a port
     protocol, host, port = split_address(ledger_address)
 
+    print(protocol + '://' + host, port)
     return protocol + '://' + host, port

--- a/fetchai/ledger/api/bootstrap.py
+++ b/fetchai/ledger/api/bootstrap.py
@@ -98,5 +98,4 @@ def server_from_name(network):
     # Check if address contains a port
     protocol, host, port = split_address(ledger_address)
 
-    print(protocol + '://' + host, port)
     return protocol + '://' + host, port


### PR DESCRIPTION
This PR makes "local" a network that connects to a local node using http on port 8000. This streamlines the experience of the API for mainnet, devnet and local.